### PR TITLE
Launcher3: quickstep: TouchInteractionService: Do not crash on boot

### DIFF
--- a/quickstep/src/com/android/quickstep/TouchInteractionService.java
+++ b/quickstep/src/com/android/quickstep/TouchInteractionService.java
@@ -564,7 +564,11 @@ public class TouchInteractionService extends Service {
                     mTaskAnimationManager, mTaskbarManager::getCurrentActivityContext);
         }
         mInputConsumer = InputConsumerController.getRecentsAnimationInputConsumer();
-        mInputConsumer.registerInputConsumer();
+        try {
+            mInputConsumer.registerInputConsumer();
+        } catch (Exception e) {
+            Log.e(TAG, "Failure registering InputConsumer", e);
+        }
         onSystemUiFlagsChanged(mDeviceState.getSystemUiStateFlags());
         onAssistantVisibilityChanged();
 


### PR DESCRIPTION
When using a 3rd party launcher most likely

Log:
E AndroidRuntime: Process: com.android.launcher3, PID: 2783 E AndroidRuntime: java.lang.RuntimeException: Error receiving broadcast Intent { act=android.intent.action.USER_UNLOCKED flg=0x50000010 (has extras) } in com.android.launcher3.util.SimpleBroadcastReceiver@89bb61a
E AndroidRuntime:        at android.app.LoadedApk$ReceiverDispatcher$Args.lambda$getRunnable$0(LoadedApk.java:1818)
E AndroidRuntime:        at android.app.LoadedApk$ReceiverDispatcher$Args.$r8$lambda$mcNAAl1SQ4MyJPyDg8TJ2x2h0Rk(Unknown Source:0)
E AndroidRuntime:        at android.app.LoadedApk$ReceiverDispatcher$Args$$ExternalSyntheticLambda0.run(D8$$SyntheticClass:0)
E AndroidRuntime:        at android.os.Handler.handleCallback(Handler.java:959)
E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:100)
E AndroidRuntime:        at android.os.Looper.loopOnce(Looper.java:232)
E AndroidRuntime:        at android.os.Looper.loop(Looper.java:317)
E AndroidRuntime:        at android.app.ActivityThread.main(ActivityThread.java:8502)
E AndroidRuntime:        at java.lang.reflect.Method.invoke(Native Method)
E AndroidRuntime:        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:554)
E AndroidRuntime:        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:878)
E AndroidRuntime: Caused by: java.lang.IllegalStateException: Existing input consumer found with name: recents_animation_input_consumer, display: 0, user: UserHandle{0}
E AndroidRuntime:        at android.os.Parcel.createExceptionOrNull(Parcel.java:3190)
E AndroidRuntime:        at android.os.Parcel.createException(Parcel.java:3166)
E AndroidRuntime:        at android.os.Parcel.readException(Parcel.java:3149)
E AndroidRuntime:        at android.os.Parcel.readException(Parcel.java:3091)
E AndroidRuntime:        at android.view.IWindowManager$Stub$Proxy.createInputConsumer(IWindowManager.java:4872)
E AndroidRuntime:        at com.android.systemui.shared.system.InputConsumerController.registerInputConsumer(go/retraceme 015d387a8a548af421dcff814eada6998d8d1f185998fc40f30bbeef937dbdc3:24)
E AndroidRuntime:        at com.android.quickstep.TouchInteractionService.onUserUnlocked(go/retraceme 015d387a8a548af421dcff814eada6998d8d1f185998fc40f30bbeef937dbdc3:51)
E AndroidRuntime:        at com.android.quickstep.TouchInteractionService$$ExternalSyntheticLambda0.run(go/retraceme 015d387a8a548af421dcff814eada6998d8d1f185998fc40f30bbeef937dbdc3:12)
E AndroidRuntime:        at com.android.launcher3.util.RunnableList.executeAllAndClear(go/retraceme 015d387a8a548af421dcff814eada6998d8d1f185998fc40f30bbeef937dbdc3:21)
E AndroidRuntime:        at com.android.launcher3.util.RunnableList.executeAllAndDestroy(go/retraceme 015d387a8a548af421dcff814eada6998d8d1f185998fc40f30bbeef937dbdc3:4)
E AndroidRuntime:        at com.android.launcher3.util.LockedUserState.access$notifyUserUnlocked(go/retraceme 015d387a8a548af421dcff814eada6998d8d1f185998fc40f30bbeef937dbdc3:3)
E AndroidRuntime:        at com.android.launcher3.util.LockedUserState$mUserUnlockedReceiver$1.accept(go/retraceme 015d387a8a548af421dcff814eada6998d8d1f185998fc40f30bbeef937dbdc3:22)
E AndroidRuntime:        at com.android.launcher3.util.SimpleBroadcastReceiver.onReceive(go/retraceme 015d387a8a548af421dcff814eada6998d8d1f185998fc40f30bbeef937dbdc3:3)
E AndroidRuntime:        at android.app.LoadedApk$ReceiverDispatcher$Args.lambda$getRunnable$0(LoadedApk.java:1810)
E AndroidRuntime:        ... 10 more
E AndroidRuntime: Caused by: android.os.RemoteException: Remote stack trace:
E AndroidRuntime:        at com.android.server.wm.InputMonitor.createInputConsumer(InputMonitor.java:226)
E AndroidRuntime:        at com.android.server.wm.WindowManagerService.createInputConsumer(WindowManagerService.java:6543)
E AndroidRuntime:        at android.view.IWindowManager$Stub.onTransact(IWindowManager.java:2612)
E AndroidRuntime:        at com.android.server.wm.WindowManagerService.onTransact(WindowManagerService.java:1406)
E AndroidRuntime:        at android.os.Binder.execTransactInternal(Binder.java:1496)